### PR TITLE
client: abstract connection as local to remote connectivity

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,8 +33,7 @@ issues:
     - "hugeParam: o is heavy"
   exclude-rules:
     - text: "string `<nil>`"
-      linters:
-        - goconst
+      linters: [goconst]
 
     # Exclude some linters from running on tests files.
     - path: _test\.go
@@ -46,31 +45,26 @@ issues:
         - goconst
 
     - path: client\.go
-      linters:
-        - maligned
+      linters: [maligned]
 
     # Ease some gocritic warnings on test files.
     - path: testutil\.go
       text: "(rangeValCopy)"
-      linters:
-        - gocritic
+      linters: [gocritic]
 
     # Ease some gocritic warnings on test files.
     - path: _test\.go
       text: "(unnamedResult|exitAfterDefer|unlambda)"
-      linters:
-        - gocritic
+      linters: [gocritic]
 
     # Exclude known linters from partially hard-vendored code,
     # which is impossible to exclude via "nolint" comments.
     - path: internal/hmac/
       text: "weak cryptographic primitive"
-      linters:
-        - gosec
+      linters: [gosec]
     - path: internal/hmac/
       text: "Write\\` is not checked"
-      linters:
-        - errcheck
+      linters: [errcheck]
 
     # Ease linting on benchmarking code.
     - path: cmd/stun-bench/
@@ -80,15 +74,14 @@ issues:
         - unparam
 
     - path: ^cmd/
-      linters:
-        - gocyclo
+      linters: [gocyclo]
     - path: ^cmd/
       text: "(unnamedResult|exitAfterDefer)"
-      linters:
-        - gocritic
+      linters: [gocritic]
     - source: "Permission struct"
-      linters:
-        - maligned
+      linters: [maligned]
+    - source: "Connection struct"
+      linters: [maligned]
 
 linters:
   enable-all: true

--- a/README.md
+++ b/README.md
@@ -56,18 +56,22 @@ func main() {
 	if createErr != nil {
 		panic(createErr)
 	}
-	// Permission implements net.Conn.
-	if _, writeRrr := fmt.Fprint(permission, "hello world!"); writeRrr != nil {
-		panic(peerAddr)
+	conn, err := permission.CreateUDP(peerAddr)
+	if err != nil {
+		panic(err)
+	}
+	// Connection implements net.Conn.
+	if _, writeRrr := fmt.Fprint(conn, "hello world!"); writeRrr != nil {
+		panic(writeRrr)
 	}
 	buf := make([]byte, 1500)
-	n, readErr := permission.Read(buf)
+	n, readErr := conn.Read(buf)
 	if readErr != nil {
 		panic(readErr)
 	}
-	fmt.Println("got message:", string(buf[:n]))
+	logger.Infof("got message: %s", string(buf[:n]))
 	// Also you can use ChannelData messages to reduce overhead:
-	if err := permission.Bind(); err != nil {
+	if err := conn.Bind(); err != nil {
 		panic(err)
 	}
 }

--- a/client_connection.go
+++ b/client_connection.go
@@ -1,0 +1,187 @@
+package turnc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"gortc.io/stun"
+	"gortc.io/turn"
+)
+
+// Connection represents a UDP connectivity between local transport address
+// and remote transport address.
+type Connection struct {
+	log          *zap.Logger
+	mux          sync.RWMutex
+	number       turn.ChannelNumber
+	peerAddr     turn.PeerAddress
+	peerL, peerR net.Conn
+	client       *Client
+	perm         *Permission
+	ctx          context.Context
+	cancel       func()
+	wg           sync.WaitGroup
+	refreshRate  time.Duration
+}
+
+// Read data from peer.
+func (c *Connection) Read(b []byte) (n int, err error) {
+	return c.peerR.Read(b)
+}
+
+// Bound returns true if channel number is bound for current permission.
+func (c *Connection) Bound() bool {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	return c.number.Valid()
+}
+
+// Binding returns current channel number or 0 if not bound.
+func (c *Connection) Binding() turn.ChannelNumber {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	return c.number
+}
+
+func (c *Connection) startLoop(f func()) {
+	if c.refreshRate == 0 {
+		return
+	}
+	c.wg.Add(1)
+	go func() {
+		ticker := time.NewTicker(c.refreshRate)
+		defer c.wg.Done()
+		for {
+			select {
+			case <-ticker.C:
+				f()
+			case <-c.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// refreshBind performs rebinding of a channel.
+func (c *Connection) refreshBind() error {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	if c.number == 0 {
+		return ErrNotBound
+	}
+	if err := c.bind(c.number); err != nil {
+		return err
+	}
+	c.log.Debug("binding refreshed")
+	return nil
+}
+
+func (c *Connection) bind(n turn.ChannelNumber) error {
+	// Starting transaction.
+	a := c.client.alloc
+	res := stun.New()
+	req := stun.New()
+	req.TransactionID = stun.NewTransactionID()
+	req.Type = stun.NewType(stun.MethodChannelBind, stun.ClassRequest)
+	req.WriteHeader()
+	setters := make([]stun.Setter, 0, 10)
+	setters = append(setters, &c.peerAddr, n)
+	if len(a.integrity) > 0 {
+		// Applying auth.
+		setters = append(setters,
+			a.nonce, a.client.username, a.client.realm, a.integrity,
+		)
+	}
+	setters = append(setters, stun.Fingerprint)
+	for _, s := range setters {
+		if setErr := s.AddTo(req); setErr != nil {
+			return setErr
+		}
+	}
+	if doErr := c.client.do(req, res); doErr != nil {
+		return doErr
+	}
+	if res.Type != stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse) {
+		return fmt.Errorf("unexpected response type %s", res.Type)
+	}
+	// Success.
+	return nil
+}
+
+// Bind performs binding transaction, allocating channel binding for
+// the connection.
+func (c *Connection) Bind() error {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	if c.number != 0 {
+		return ErrAlreadyBound
+	}
+	a := c.client.alloc
+	a.minBound++
+	n := a.minBound
+	if err := c.bind(n); err != nil {
+		return err
+	}
+	c.number = n
+	c.startLoop(func() {
+		if err := c.refreshBind(); err != nil {
+			c.log.Error("failed to refresh bind", zap.Error(err))
+		}
+	})
+	return nil
+}
+
+// Write sends buffer to peer.
+//
+// If permission is bound, the ChannelData message will be used.
+func (c *Connection) Write(b []byte) (n int, err error) {
+	if n := c.Binding(); n.Valid() {
+		c.log.Debug("using channel data to write")
+		return c.client.sendChan(b, n)
+	}
+	c.log.Debug("using STUN to write")
+	return c.client.sendData(b, &c.peerAddr)
+}
+
+// Close stops all refreshing loops for permission and removes it from
+// allocation.
+func (c *Connection) Close() error {
+	cErr := c.peerR.Close()
+	c.mux.Lock()
+	cancel := c.cancel
+	c.mux.Unlock()
+	cancel()
+	c.wg.Wait()
+	c.perm.removeConn(c)
+	return cErr
+}
+
+// LocalAddr is relayed address from TURN server.
+func (c *Connection) LocalAddr() net.Addr {
+	return turn.Addr(c.client.alloc.relayed)
+}
+
+// RemoteAddr is peer address.
+func (c *Connection) RemoteAddr() net.Addr {
+	return turn.Addr(c.peerAddr)
+}
+
+// SetDeadline implements net.Conn.
+func (c *Connection) SetDeadline(t time.Time) error {
+	return c.peerR.SetDeadline(t)
+}
+
+// SetReadDeadline implements net.Conn.
+func (c *Connection) SetReadDeadline(t time.Time) error {
+	return c.peerR.SetReadDeadline(t)
+}
+
+// SetWriteDeadline implements net.Conn.
+func (c *Connection) SetWriteDeadline(t time.Time) error {
+	return ErrNotImplemented
+}

--- a/client_permission.go
+++ b/client_permission.go
@@ -3,48 +3,26 @@ package turnc
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
 
-	"gortc.io/stun"
 	"gortc.io/turn"
 )
 
 // Permission implements net.PacketConn.
 type Permission struct {
-	log          *zap.Logger
-	mux          sync.RWMutex
-	number       turn.ChannelNumber
-	peerAddr     turn.PeerAddress
-	peerL, peerR net.Conn
-	client       *Client
-	ctx          context.Context
-	cancel       func()
-	wg           sync.WaitGroup
-	refreshRate  time.Duration
-}
-
-// Read data from peer.
-func (p *Permission) Read(b []byte) (n int, err error) {
-	return p.peerR.Read(b)
-}
-
-// Bound returns true if channel number is bound for current permission.
-func (p *Permission) Bound() bool {
-	p.mux.RLock()
-	defer p.mux.RUnlock()
-	return p.number.Valid()
-}
-
-// Binding returns current channel number or 0 if not bound.
-func (p *Permission) Binding() turn.ChannelNumber {
-	p.mux.RLock()
-	defer p.mux.RUnlock()
-	return p.number
+	log         *zap.Logger
+	mux         sync.RWMutex
+	ip          net.IP
+	client      *Client
+	ctx         context.Context
+	cancel      func()
+	wg          sync.WaitGroup
+	refreshRate time.Duration
+	conn        []*Connection
 }
 
 var (
@@ -55,7 +33,7 @@ var (
 )
 
 func (p *Permission) refresh() error {
-	return p.client.alloc.allocate(p.peerAddr)
+	return p.client.alloc.allocate(turn.PeerAddress{IP: p.ip})
 }
 
 func (p *Permission) startLoop(f func()) {
@@ -86,125 +64,45 @@ func (p *Permission) startRefreshLoop() {
 	})
 }
 
-// refreshBind performs rebinding of a channel.
-func (p *Permission) refreshBind() error {
-	p.mux.Lock()
-	defer p.mux.Unlock()
-	if p.number == 0 {
-		return ErrNotBound
-	}
-	if err := p.bind(p.number); err != nil {
-		return err
-	}
-	p.log.Debug("binding refreshed")
-	return nil
-}
-
-func (p *Permission) bind(n turn.ChannelNumber) error {
-	// Starting transaction.
-	a := p.client.alloc
-	res := stun.New()
-	req := stun.New()
-	req.TransactionID = stun.NewTransactionID()
-	req.Type = stun.NewType(stun.MethodChannelBind, stun.ClassRequest)
-	req.WriteHeader()
-	setters := make([]stun.Setter, 0, 10)
-	setters = append(setters, &p.peerAddr, n)
-	if len(a.integrity) > 0 {
-		// Applying auth.
-		setters = append(setters,
-			a.nonce, a.client.username, a.client.realm, a.integrity,
-		)
-	}
-	setters = append(setters, stun.Fingerprint)
-	for _, s := range setters {
-		if setErr := s.AddTo(req); setErr != nil {
-			return setErr
-		}
-	}
-	if doErr := p.client.do(req, res); doErr != nil {
-		return doErr
-	}
-	if res.Type != stun.NewType(stun.MethodChannelBind, stun.ClassSuccessResponse) {
-		return fmt.Errorf("unexpected response type %s", res.Type)
-	}
-	// Success.
-	return nil
-}
-
-// Bind performs binding transaction, allocating channel binding for
-// the permission.
-func (p *Permission) Bind() error {
-	p.mux.Lock()
-	defer p.mux.Unlock()
-	if p.number != 0 {
-		return ErrAlreadyBound
-	}
-	a := p.client.alloc
-	a.minBound++
-	n := a.minBound
-	if err := p.bind(n); err != nil {
-		return err
-	}
-	p.number = n
-	p.startLoop(func() {
-		if err := p.refreshBind(); err != nil {
-			p.log.Error("failed to refresh bind", zap.Error(err))
-		}
-	})
-	return nil
-}
-
-// Write sends buffer to peer.
-//
-// If permission is bound, the ChannelData message will be used.
-func (p *Permission) Write(b []byte) (n int, err error) {
-	if n := p.Binding(); n.Valid() {
-		p.log.Debug("using channel data to write")
-		return p.client.sendChan(b, n)
-	}
-	p.log.Debug("using STUN to write")
-	return p.client.sendData(b, &p.peerAddr)
+// WriteTo writes packet b to addr.
+func (p *Permission) WriteTo(b []byte, addr net.Addr) (n int, err error) {
+	return 0, ErrNotImplemented
 }
 
 // Close stops all refreshing loops for permission and removes it from
 // allocation.
 func (p *Permission) Close() error {
-	cErr := p.peerR.Close()
 	p.mux.Lock()
 	cancel := p.cancel
 	p.mux.Unlock()
 	cancel()
 	p.wg.Wait()
 	p.client.alloc.removePermission(p)
-	return cErr
-}
-
-// LocalAddr is relayed address from TURN server.
-func (p *Permission) LocalAddr() net.Addr {
-	return turn.Addr(p.client.alloc.relayed)
-}
-
-// RemoteAddr is peer address.
-func (p *Permission) RemoteAddr() net.Addr {
-	return turn.Addr(p.peerAddr)
-}
-
-// SetDeadline implements net.Conn.
-func (p *Permission) SetDeadline(t time.Time) error {
-	return p.peerR.SetDeadline(t)
-}
-
-// SetReadDeadline implements net.Conn.
-func (p *Permission) SetReadDeadline(t time.Time) error {
-	return p.peerR.SetReadDeadline(t)
+	return nil
 }
 
 // ErrNotImplemented means that functionality is not currently implemented,
 // but it will be (eventually).
 var ErrNotImplemented = errors.New("functionality not implemented")
 
-// SetWriteDeadline implements net.Conn.
-func (p *Permission) SetWriteDeadline(t time.Time) error {
-	return ErrNotImplemented
+func (p *Permission) removeConn(connection *Connection) {}
+
+// CreateUDP creates new UDP Permission to peer with provided addr.
+func (p *Permission) CreateUDP(addr *net.UDPAddr) (*Connection, error) {
+	peer := turn.PeerAddress{
+		IP:   addr.IP,
+		Port: addr.Port,
+	}
+	c := &Connection{
+		log:         p.log,
+		peerAddr:    peer,
+		client:      p.client,
+		refreshRate: p.client.refreshRate,
+	}
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+	c.peerL, c.peerR = net.Pipe()
+	p.client.mux.Lock()
+	p.conn = append(p.conn, c)
+	p.client.mux.Unlock()
+	return c, nil
 }

--- a/client_permission_test.go
+++ b/client_permission_test.go
@@ -79,7 +79,7 @@ func TestPermission(t *testing.T) {
 					}
 					return nil
 				}
-				p, permErr := a.CreateUDP(peer)
+				p, permErr := a.Create(peer.IP)
 				if permErr != nil {
 					t.Fatal(allocErr)
 				}
@@ -161,7 +161,7 @@ func TestPermission(t *testing.T) {
 					}
 					return nil
 				}
-				p, permErr := a.CreateUDP(peer)
+				p, permErr := a.Create(peer.IP)
 				if permErr != nil {
 					t.Fatal(permErr)
 				}
@@ -256,11 +256,15 @@ func TestPermission(t *testing.T) {
 					}
 					return nil
 				}
-				p, permErr := a.CreateUDP(peer)
+				p, permErr := a.Create(peer.IP)
 				if permErr != nil {
 					t.Fatal(allocErr)
 				}
-				if err := p.Bind(); err != nil {
+				conn, err := p.CreateUDP(peer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := conn.Bind(); err != nil {
 					t.Fatal(err)
 				}
 				select {
@@ -349,11 +353,15 @@ func TestPermission(t *testing.T) {
 					}
 					return nil
 				}
-				p, permErr := a.CreateUDP(peer)
+				p, permErr := a.Create(peer.IP)
 				if permErr != nil {
 					t.Fatal(allocErr)
 				}
-				if err := p.Bind(); err != nil {
+				conn, err := p.CreateUDP(peer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := conn.Bind(); err != nil {
 					t.Fatal(err)
 				}
 				select {
@@ -444,14 +452,18 @@ func TestPermission(t *testing.T) {
 					}
 					return nil
 				}
-				p, permErr := a.CreateUDP(peer)
+				p, permErr := a.Create(peer.IP)
 				if permErr != nil {
 					t.Fatal(allocErr)
 				}
-				if err := p.Bind(); err != nil {
+				conn, err := p.CreateUDP(peer)
+				if err != nil {
 					t.Fatal(err)
 				}
-				if err := p.Close(); err != nil {
+				if err := conn.Bind(); err != nil {
+					t.Fatal(err)
+				}
+				if err := conn.Close(); err != nil {
 					t.Error(err)
 				}
 				if err := connL.Close(); err != nil {
@@ -566,11 +578,15 @@ func TestPermission(t *testing.T) {
 					}
 					return nil
 				}
-				p, permErr := a.CreateUDP(peer)
+				p, permErr := a.Create(peer.IP)
 				if permErr != nil {
 					t.Fatal(allocErr)
 				}
-				if err := p.Bind(); err != nil {
+				conn, err := p.CreateUDP(peer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := conn.Bind(); err != nil {
 					t.Fatal(err)
 				}
 				select {
@@ -579,7 +595,7 @@ func TestPermission(t *testing.T) {
 				case <-time.After(time.Second):
 					t.Error("timed out")
 				}
-				if err := p.Close(); err != nil {
+				if err := conn.Close(); err != nil {
 					t.Error(err)
 				}
 				connL.Close()

--- a/cmd/turn-client/client.go
+++ b/cmd/turn-client/client.go
@@ -95,15 +95,19 @@ func main() {
 	if resolveErr != nil {
 		panic(resolveErr)
 	}
-	permission, createErr := a.Create(peerAddr)
+	permission, createErr := a.Create(peerAddr.IP)
 	if createErr != nil {
 		panic(createErr)
 	}
-	if _, writeRrr := fmt.Fprint(permission, "hello world!"); writeRrr != nil {
+	conn, err := permission.CreateUDP(peerAddr)
+	if err != nil {
+		panic(err)
+	}
+	if _, writeRrr := fmt.Fprint(conn, "hello world!"); writeRrr != nil {
 		panic(writeRrr)
 	}
 	buf := make([]byte, 1500)
-	n, readErr := permission.Read(buf)
+	n, readErr := conn.Read(buf)
 	if readErr != nil {
 		panic(readErr)
 	}

--- a/e2e/turn-client/main.go
+++ b/e2e/turn-client/main.go
@@ -95,17 +95,21 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to create allocation: %v", err))
 	}
-	p, err := a.Create(echoAddr)
+	p, err := a.Create(echoAddr.IP)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create permission: %v", err))
 	}
+	conn, err := p.CreateUDP(echoAddr)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create connection: %v", err))
+	}
 	// Sending and receiving "hello" message.
-	if _, err := fmt.Fprint(p, "hello"); err != nil {
+	if _, err := fmt.Fprint(conn, "hello"); err != nil {
 		panic(fmt.Sprintf("failed to write data"))
 	}
 	sent := []byte("hello")
 	got := make([]byte, len(sent))
-	if _, err = p.Read(got); err != nil {
+	if _, err = conn.Read(got); err != nil {
 		panic(fmt.Sprintf("failed to read data: %v", err))
 	}
 	if !bytes.Equal(got, sent) {
@@ -115,18 +119,18 @@ func main() {
 	for i := range got {
 		got[i] = 0
 	}
-	if bindErr := p.Bind(); bindErr != nil {
+	if bindErr := conn.Bind(); bindErr != nil {
 		panic(fmt.Sprintf("failed to bind: %v", err))
 	}
-	if !p.Bound() {
+	if !conn.Bound() {
 		panic(fmt.Sprintf("should be bound"))
 	}
-	logger.Sugar().Infof("bound to channel 0x%x", int(p.Binding()))
+	logger.Sugar().Infof("bound to channel 0x%x", int(conn.Binding()))
 	// Sending and receiving "hello" message.
-	if _, err := fmt.Fprint(p, "hello"); err != nil {
+	if _, err := fmt.Fprint(conn, "hello"); err != nil {
 		panic(fmt.Sprintf("failed to write data"))
 	}
-	if _, err = p.Read(got); err != nil {
+	if _, err = conn.Read(got); err != nil {
 		panic(fmt.Sprintf("failed to read data: %v", err))
 	}
 	if !bytes.Equal(got, sent) {


### PR DESCRIPTION
Permission is IP-only, port is non-restricted.
This commit fixes incorrect abstraction.

Fixes #3